### PR TITLE
New version

### DIFF
--- a/handlers/__init__.py
+++ b/handlers/__init__.py
@@ -1,5 +1,4 @@
 from handlers import client
 from handlers import faq
 from handlers import events
-# from handlers import admin
-# from handlers import other
+

--- a/handlers/client.py
+++ b/handlers/client.py
@@ -169,7 +169,7 @@ async def load_gmt(message: types.Message, state: FSMContext):
 
 @client_router.message(FSMClient.comment)
 async def load_comment(message: types.Message, state: FSMContext):
-    """ Save a comment and save all state in db.
+    """ Save a comment and save all states in db.
         Finish current state """
     await delete_message(message)
     await state.update_data(comment=sanitize_text(message.text))

--- a/handlers/other.py
+++ b/handlers/other.py
@@ -1,9 +1,6 @@
-import json
-import string
 from aiogram import types, Router, Bot
 from aiogram.filters import Command
 
-from create_bot import bot
 from filters.chat_types import ChatTypeFilter
 
 """ Censoring filter """
@@ -14,8 +11,10 @@ user_group_router.edited_message.filter(ChatTypeFilter(["group", "supergroup"]))
 
 @user_group_router.message(Command("admin"))
 async def get_admins(message: types.Message, bot: Bot):
+    """ This function is the first part of the two-factor authentication analog,
+    catches the Admin command in the admin chat and identifies the rank of the user
+    in this chat, keeping the ID in the list that is used in the custom IsAdmin filter. """
     chat_id = message.chat.id
-    print("Command /admin is called")
     admins_list = await bot.get_chat_administrators(chat_id)
     admins_list = [
         member.user.id

--- a/keyboards/__init__.py
+++ b/keyboards/__init__.py
@@ -1,2 +1,2 @@
 from keyboards.client_kb import cancel_state_kb, main_menu_kb, get_menu_kb, get_faq_keyboard, get_meetings_kb, get_back_to_meetings_kb
-# from keyboards.admin_kb import admins_kb, admins_menu_kb
+

--- a/keyboards/admin_kb.py
+++ b/keyboards/admin_kb.py
@@ -22,7 +22,9 @@ def admin_keyboard() -> InlineKeyboardMarkup:
         types.InlineKeyboardButton(text='👀 Список участников встречи',
                                    callback_data='Show_list'),
         types.InlineKeyboardButton(text='❌ Удалить список участников встречи',
-                                   callback_data='Delete_list')
+                                   callback_data='Delete_list'),
+        types.InlineKeyboardButton(text='Вернуться в меню',
+                                   callback_data='Menu')
     ]
     keyboard = InlineKeyboardBuilder()
     keyboard.add(*buttons_list)

--- a/main_bot.py
+++ b/main_bot.py
@@ -32,7 +32,7 @@ logger.addHandler(file_handler)
 logger.propagate = False
 
 # pip install:
-# aiogram framework (bot is written on 3.3.0 version of aiogram)
+# aiogram framework (bot written in version 3.3.0 of aiogram)
 # sqlalchemy
 # aiosqlite
 # python-dotenv


### PR DESCRIPTION
#
<h3>In this version:</h3>

- added login/password authentication for bot admin. At this point, the bot uses the .env file to check for the correct combination. I intend to change this so that the comparison is made with a table in the database. 
Now this is two-factor auth: 
1 step. You should be admin in special Telegram chat where this bot is admin. 
2 step. You should write your login and password
#